### PR TITLE
Replace `container-interop/container-interop`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "ext-mbstring": "*",
-        "container-interop/container-interop": "^1.2",
+        "psr/container": "^1.0.0",
         "laminas/laminas-math": "^3.0",
         "laminas/laminas-stdlib": "^2.7.7 || ^3.1",
         "laminas/laminas-zendframework-bridge": "^1.0"


### PR DESCRIPTION
Replace deprecated `container-interop/container-interop` with `psr/container`

"Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead."