### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "ext-mbstring": "*",
         "container-interop/container-interop": "^1.2",
         "laminas/laminas-math": "^3.4",
-        "laminas/laminas-stdlib": "^3.6",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
@@ -56,7 +55,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-crypt": "^3.3.1"
+    "conflict": {
+        "zendframework/zend-crypt": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54cb5a0fe3630652246e2e51501a46d7",
+    "content-hash": "14c05430dfcce2bd6ccc373d5d587a13",
     "packages": [
         {
             "name": "container-interop/container-interop",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
