### PR TITLE
Switch from `container-interop/container-interop` to `psr/container` in a backward compatible manner

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     "require": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-mbstring": "*",
-        "container-interop/container-interop": "^1.2",
         "laminas/laminas-math": "^3.4",
-        "laminas/laminas-stdlib": "^3.6"
+        "laminas/laminas-stdlib": "^3.6",
+        "psr/container": "^1.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.3.0",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-mbstring": "*",
         "laminas/laminas-math": "^3.4",
+        "laminas/laminas-servicemanager": "^3.11.2",
         "laminas/laminas-stdlib": "^3.6",
         "psr/container": "^1.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1e205fda02b1a3469bd9b71e8e32925",
+    "content-hash": "0e1645500a71ee26744bd7f1effe07d6",
     "packages": [
         {
             "name": "laminas/laminas-math",
@@ -72,6 +72,97 @@
                 }
             ],
             "time": "2021-12-06T02:02:07+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "8a1f4d53ec93b2e18174f6f186922ef44d11a75a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/8a1f4d53ec93b2e18174f6f186922ef44d11a75a",
+                "reference": "8a1f4d53ec93b2e18174f6f186922ef44d11a75a",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.2.1",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<3.3.1",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.6",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.8"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-04-07T17:21:25+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",

--- a/composer.lock
+++ b/composer.lock
@@ -4,44 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b78368a862df1ea77c36235c346cd008",
+    "content-hash": "b1e205fda02b1a3469bd9b71e8e32925",
     "packages": [
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
-            },
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
         {
             "name": "laminas/laminas-math",
             "version": "3.5.0",

--- a/src/BlockCipher.php
+++ b/src/BlockCipher.php
@@ -2,11 +2,11 @@
 
 namespace Laminas\Crypt;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\NotFoundException;
 use Laminas\Crypt\Key\Derivation\Pbkdf2;
 use Laminas\Crypt\Symmetric\SymmetricInterface;
 use Laminas\Math\Rand;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface as NotFoundException;
 
 use function base64_decode;
 use function base64_encode;

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -3,11 +3,11 @@
 namespace Laminas\Crypt\Exception;
 
 use DomainException;
-use Interop\Container\Exception\NotFoundException as InteropNotFoundException;
+use Psr\Container\NotFoundExceptionInterface as PsrNotFoundException;
 
 /**
  * Runtime argument exception
  */
-class NotFoundException extends DomainException implements InteropNotFoundException
+class NotFoundException extends DomainException implements PsrNotFoundException
 {
 }

--- a/src/Symmetric/Mcrypt.php
+++ b/src/Symmetric/Mcrypt.php
@@ -2,8 +2,8 @@
 
 namespace Laminas\Crypt\Symmetric;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Stdlib\ArrayUtils;
+use Psr\Container\ContainerInterface;
 use Traversable;
 
 use function array_key_exists;
@@ -82,7 +82,7 @@ class Mcrypt implements SymmetricInterface
     /**
      * Padding plugins
      *
-     * @var Interop\Container\ContainerInterface
+     * @var ContainerInterface
      */
     protected static $paddingPlugins;
 
@@ -239,7 +239,7 @@ class Mcrypt implements SymmetricInterface
         }
         if (! $plugins instanceof ContainerInterface) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Padding plugins must implements Interop\Container\ContainerInterface; received "%s"',
+                'Padding plugins must implements Psr\Container\ContainerInterface; received "%s"',
                 is_object($plugins) ? get_class($plugins) : gettype($plugins)
             ));
         }

--- a/src/Symmetric/Openssl.php
+++ b/src/Symmetric/Openssl.php
@@ -2,8 +2,8 @@
 
 namespace Laminas\Crypt\Symmetric;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Stdlib\ArrayUtils;
+use Psr\Container\ContainerInterface;
 use Traversable;
 
 use function array_push;
@@ -80,7 +80,7 @@ class Openssl implements SymmetricInterface
     /**
      * Padding plugins
      *
-     * @var Interop\Container\ContainerInterface
+     * @var ContainerInterface
      */
     protected static $paddingPlugins;
 

--- a/src/Symmetric/PaddingPluginManager.php
+++ b/src/Symmetric/PaddingPluginManager.php
@@ -2,7 +2,7 @@
 
 namespace Laminas\Crypt\Symmetric;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use function array_key_exists;
 use function sprintf;

--- a/src/SymmetricPluginManager.php
+++ b/src/SymmetricPluginManager.php
@@ -2,7 +2,7 @@
 
 namespace Laminas\Crypt;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 use function array_key_exists;
 use function sprintf;

--- a/test/BlockCipher/AbstractBlockCipherTest.php
+++ b/test/BlockCipher/AbstractBlockCipherTest.php
@@ -2,11 +2,11 @@
 
 namespace LaminasTest\Crypt\BlockCipher;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Crypt\BlockCipher;
 use Laminas\Crypt\Exception;
 use Laminas\Crypt\Symmetric;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 use function file_get_contents;
 use function get_class;

--- a/test/Symmetric/AbstractTest.php
+++ b/test/Symmetric/AbstractTest.php
@@ -3,12 +3,12 @@
 namespace LaminasTest\Crypt\Symmetric;
 
 use ArrayObject;
-use Interop\Container\ContainerInterface;
 use Laminas\Crypt\Symmetric\Exception;
 use Laminas\Crypt\Symmetric\Padding\NoPadding;
 use Laminas\Crypt\Symmetric\Padding\PKCS7;
 use Laminas\Math\Rand;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use stdClass;
 
 use function file_get_contents;

--- a/test/Symmetric/Padding/PaddingPluginManagerTest.php
+++ b/test/Symmetric/Padding/PaddingPluginManagerTest.php
@@ -2,11 +2,11 @@
 
 namespace LaminasTest\Crypt\Symmetric\Padding;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Crypt\Symmetric\Exception;
 use Laminas\Crypt\Symmetric\Padding\PaddingInterface;
 use Laminas\Crypt\Symmetric\PaddingPluginManager;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 class PaddingPluginManagerTest extends TestCase
 {

--- a/test/SymmetricPluginManagerTest.php
+++ b/test/SymmetricPluginManagerTest.php
@@ -2,12 +2,12 @@
 
 namespace LaminasTest\Crypt;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Crypt\Exception as CryptException;
 use Laminas\Crypt\Symmetric\Exception;
 use Laminas\Crypt\Symmetric\SymmetricInterface;
 use Laminas\Crypt\SymmetricPluginManager;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 use function extension_loaded;
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

This patch switches from using container-interop as a dependency to using laminas-servicemanager 3.11.2+.
Internally, it also modifies all container-interop implementations to be psr/container implementations, and modifies type-checking to check against psr/container instead of container-interop.

Since laminas-servicemanager at those versions provides and replaces container-interop, this change is backwards compatible.
([This demonstration](https://github.com/laminas/laminas-crypt/issues/20#issuecomment-1096746548) validates the approach.)

Fixes #20 