### PR TITLE
Allow psr/container v2 [BC Break]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-mbstring": "*",
         "laminas/laminas-math": "^3.4",
         "laminas/laminas-stdlib": "^3.8",
-        "psr/container": "^1.1"
+        "psr/container": "^1.1 || ^2.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19311d0dfaaf5ea3310ccbed134ba734",
+    "content-hash": "e7317805781232fe01860ac47b8a5a11",
     "packages": [
         {
             "name": "laminas/laminas-math",
@@ -2105,12 +2105,12 @@
             "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },

--- a/src/Symmetric/PaddingPluginManager.php
+++ b/src/Symmetric/PaddingPluginManager.php
@@ -25,11 +25,8 @@ class PaddingPluginManager implements ContainerInterface
 
     /**
      * Do we have the padding plugin?
-     *
-     * @param  string $id
-     * @return bool
      */
-    public function has($id)
+    public function has(string $id): bool
     {
         return array_key_exists($id, $this->paddings);
     }
@@ -37,10 +34,9 @@ class PaddingPluginManager implements ContainerInterface
     /**
      * Retrieve the padding plugin
      *
-     * @param  string $id
      * @return Padding\PaddingInterface
      */
-    public function get($id)
+    public function get(string $id)
     {
         if (! $this->has($id)) {
             throw new Exception\NotFoundException(sprintf(

--- a/src/Symmetric/PaddingPluginManager.php
+++ b/src/Symmetric/PaddingPluginManager.php
@@ -14,7 +14,7 @@ use function sprintf;
  * Padding\PaddingInterface. Additionally, it registers a number of default
  * padding adapters available.
  */
-class PaddingPluginManager implements ContainerInterface
+final class PaddingPluginManager implements ContainerInterface
 {
     /** @var array<string, string> */
     private $paddings = [

--- a/src/SymmetricPluginManager.php
+++ b/src/SymmetricPluginManager.php
@@ -28,11 +28,8 @@ class SymmetricPluginManager implements ContainerInterface
 
     /**
      * Do we have the symmetric plugin?
-     *
-     * @param  string $id
-     * @return bool
      */
-    public function has($id)
+    public function has(string $id): bool
     {
         return array_key_exists($id, $this->symmetric);
     }
@@ -40,10 +37,9 @@ class SymmetricPluginManager implements ContainerInterface
     /**
      * Retrieve the symmetric plugin
      *
-     * @param  string $id
      * @return Symmetric\SymmetricInterface
      */
-    public function get($id)
+    public function get(string $id)
     {
         if (! $this->has($id)) {
             throw new Exception\NotFoundException(sprintf(

--- a/src/SymmetricPluginManager.php
+++ b/src/SymmetricPluginManager.php
@@ -14,7 +14,7 @@ use function sprintf;
  * Symmetric\SymmetricInterface. Additionally, it registers a number of default
  * symmetric adapters available.
  */
-class SymmetricPluginManager implements ContainerInterface
+final class SymmetricPluginManager implements ContainerInterface
 {
     /**
      * Default set of symmetric adapters


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break  | yes
| New Feature   | yes

### Description
For a laminas/laminas-servicemanager v4 upgrade this package must allow psr/container v2

The added type hints are allowed for the existing psr/container package v1 and are required for psr/container v2
